### PR TITLE
Typo in cascade example?

### DIFF
--- a/content/lessons/2-4-cascade.md
+++ b/content/lessons/2-4-cascade.md
@@ -9,7 +9,7 @@ context: "language-tour"
 The cascade operator lets you perform a series of operations on the same object. It's basically syntactic sugar:
 
 ```dart
-class Human {
+class Person {
   final firstName;
   final lastName;
   final age;


### PR DESCRIPTION
I think it should be `class Person` instead of `Human`, am I right?